### PR TITLE
fixup: publishing information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/target
+*/target
+/Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "device_tree"
-version = "1.0.3"
+name = "flat_device_tree"
+version = "2.1.0"
 edition = "2021"
-authors = ["Marc Brinkmann <git@marcbrinkmann.de>"]
+authors = ["Marc Brinkmann <git@marcbrinkmann.de>", "Rust device_tree developers"]
 license = "MIT"
 description = "Reads and parses Linux device tree images"
-repository = "https://github.com/mbr/device_tree-rs"
-documentation = "https://mbr.github.io/device_tree-rs/device_tree/"
+repository = "https://codeberg.org/weathered-steel/flat_device_tree"
+documentation = "https://docs.rs/flat_device_tree"
 
 [dependencies]
 hashbrown = "0.13"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# `device_tree`: Parse flattened Linux device trees
+# `flat_device_tree`: Parse flattened Linux device trees
+
+**NOTE**: `flat_device_tree` development has moved to [Codeberg](https://codeberg.org/weathered-steel/flat_device_tree)
 
 Device trees are used to describe a lot of hardware, especially in the ARM embedded world and are also used to boot Linux on these device. A device tree describes addresses and other attributes for many parts on these boards.
 


### PR DESCRIPTION
Change the crate name for maintained publishing to crates.io

Change crate URL to Codeberg